### PR TITLE
CORS 500에러 해결을 위한 시큐리티 설정 변경

### DIFF
--- a/src/main/java/WebProject/withpet/common/config/SecurityConfig.java
+++ b/src/main/java/WebProject/withpet/common/config/SecurityConfig.java
@@ -81,7 +81,7 @@ public class SecurityConfig {
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
 
-        configuration.addAllowedOrigin("*");
+        configuration.addAllowedOriginPattern("*");
         configuration.addAllowedHeader("*");
         configuration.addAllowedMethod("*");
         configuration.setAllowCredentials(true);


### PR DESCRIPTION


## 📌 관련 이슈
 When allowCredentials is true, allowedOrigins cannot contain the special value "*" since that cannot be set on the "Access-Control-Allow-Origin" response header. 500에러 해결을 위한 시큐리티 설정 변경


## ✨ 추가된 내용



## 📚 논의사항
