### PR TITLE
feat: 가계부 crud 기능 구현

### DIFF
--- a/src/main/java/WebProject/withpet/pets/controller/ConsumptionController.java
+++ b/src/main/java/WebProject/withpet/pets/controller/ConsumptionController.java
@@ -5,7 +5,8 @@ import WebProject.withpet.common.constants.ResponseConstants;
 import WebProject.withpet.common.constants.ResponseMessages;
 import WebProject.withpet.common.dto.ApiResponse;
 import WebProject.withpet.pets.dto.ConsumptionRequestDto;
-import WebProject.withpet.pets.dto.ConsumptionResponseDto;
+import WebProject.withpet.pets.dto.MonthlyConsumptionByPetResponseDto;
+import WebProject.withpet.pets.dto.MonthlyConsumptionByUserResponseDto;
 import WebProject.withpet.pets.service.ConsumptionService;
 import java.util.List;
 import javax.validation.Valid;
@@ -18,17 +19,15 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/pet/{petId}/consumption")
 public class ConsumptionController {
     private final ConsumptionService consumptionService;
 
-    @PostMapping
+    @PostMapping("/pet/{petId}/consumption")
     public ResponseEntity<ApiResponse<Void>> saveConsumption(@AuthenticationPrincipal PrincipalDetails principalDetails,
                                                              @Valid @RequestBody ConsumptionRequestDto request,
                                                              @PathVariable Long petId) {
@@ -36,7 +35,7 @@ public class ConsumptionController {
         return ResponseEntity.ok(ResponseConstants.RESPONSE_SAVE_OK);
     }
 
-    @PutMapping("/{consumptionId}")
+    @PutMapping("/pet/{petId}/consumption/{consumptionId}")
     public ResponseEntity<ApiResponse<Void>> updateConsumption(
             @AuthenticationPrincipal PrincipalDetails principalDetails,
             @Valid @RequestBody ConsumptionRequestDto request, @PathVariable Long petId,
@@ -45,7 +44,7 @@ public class ConsumptionController {
         return ResponseEntity.ok(ResponseConstants.RESPONSE_UPDATE_OK);
     }
 
-    @DeleteMapping("/{consumptionId}")
+    @DeleteMapping("/pet/{petId}/consumption/{consumptionId}")
     public ResponseEntity<ApiResponse<Void>> deleteConsumption(
             @AuthenticationPrincipal PrincipalDetails principalDetails, @PathVariable Long petId,
             @PathVariable Long consumptionId) {
@@ -53,13 +52,23 @@ public class ConsumptionController {
         return ResponseEntity.ok(ResponseConstants.RESPONSE_DEL_OK);
     }
 
-    @GetMapping
-    public ResponseEntity<ApiResponse<List<ConsumptionResponseDto>>> getMonthlyConsumptions(
+    @GetMapping("/pet/{petId}/consumption")
+    public ResponseEntity<ApiResponse<List<MonthlyConsumptionByPetResponseDto>>> getMonthlyConsumptionsByPet(
             @AuthenticationPrincipal PrincipalDetails principalDetails, @PathVariable Long petId,
             @RequestParam int year, @RequestParam int month) {
-        ApiResponse<List<ConsumptionResponseDto>> response = new ApiResponse<>(200,
+        ApiResponse<List<MonthlyConsumptionByPetResponseDto>> response = new ApiResponse<>(200,
                 ResponseMessages.VIEW_MESSAGE.getContent(),
-                consumptionService.getMonthlyConsumptions(petId, principalDetails.getUser(), year, month));
+                consumptionService.getMonthlyConsumptionsByPet(petId, principalDetails.getUser(), year, month));
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/pet/consumption")
+    public ResponseEntity<ApiResponse<List<MonthlyConsumptionByUserResponseDto>>> getMonthlyConsumptionsByUser(
+            @AuthenticationPrincipal PrincipalDetails principalDetails, @RequestParam int year,
+            @RequestParam int month) {
+        ApiResponse<List<MonthlyConsumptionByUserResponseDto>> response = new ApiResponse<>(200,
+                ResponseMessages.VIEW_MESSAGE.getContent(),
+                consumptionService.getMonthlyConsumptionsByUser(principalDetails.getUser(), year, month));
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/WebProject/withpet/pets/controller/ConsumptionController.java
+++ b/src/main/java/WebProject/withpet/pets/controller/ConsumptionController.java
@@ -1,0 +1,65 @@
+package WebProject.withpet.pets.controller;
+
+import WebProject.withpet.common.auth.PrincipalDetails;
+import WebProject.withpet.common.constants.ResponseConstants;
+import WebProject.withpet.common.constants.ResponseMessages;
+import WebProject.withpet.common.dto.ApiResponse;
+import WebProject.withpet.pets.dto.ConsumptionRequestDto;
+import WebProject.withpet.pets.dto.ConsumptionResponseDto;
+import WebProject.withpet.pets.service.ConsumptionService;
+import java.util.List;
+import javax.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/pet/{petId}/consumption")
+public class ConsumptionController {
+    private final ConsumptionService consumptionService;
+
+    @PostMapping
+    public ResponseEntity<ApiResponse<Void>> saveConsumption(@AuthenticationPrincipal PrincipalDetails principalDetails,
+                                                             @Valid @RequestBody ConsumptionRequestDto request,
+                                                             @PathVariable Long petId) {
+        consumptionService.saveConsumption(petId, principalDetails.getUser(), request);
+        return ResponseEntity.ok(ResponseConstants.RESPONSE_SAVE_OK);
+    }
+
+    @PutMapping("/{consumptionId}")
+    public ResponseEntity<ApiResponse<Void>> updateConsumption(
+            @AuthenticationPrincipal PrincipalDetails principalDetails,
+            @Valid @RequestBody ConsumptionRequestDto request, @PathVariable Long petId,
+            @PathVariable Long consumptionId) {
+        consumptionService.updateConsumption(consumptionId, petId, principalDetails.getUser(), request);
+        return ResponseEntity.ok(ResponseConstants.RESPONSE_UPDATE_OK);
+    }
+
+    @DeleteMapping("/{consumptionId}")
+    public ResponseEntity<ApiResponse<Void>> deleteConsumption(
+            @AuthenticationPrincipal PrincipalDetails principalDetails, @PathVariable Long petId,
+            @PathVariable Long consumptionId) {
+        consumptionService.deleteConsumption(consumptionId, petId, principalDetails.getUser());
+        return ResponseEntity.ok(ResponseConstants.RESPONSE_DEL_OK);
+    }
+
+    @GetMapping
+    public ResponseEntity<ApiResponse<List<ConsumptionResponseDto>>> getMonthlyConsumptions(
+            @AuthenticationPrincipal PrincipalDetails principalDetails, @PathVariable Long petId,
+            @RequestParam int year, @RequestParam int month) {
+        ApiResponse<List<ConsumptionResponseDto>> response = new ApiResponse<>(200,
+                ResponseMessages.VIEW_MESSAGE.getContent(),
+                consumptionService.getMonthlyConsumptions(petId, principalDetails.getUser(), year, month));
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/WebProject/withpet/pets/domain/Comsumption.java
+++ b/src/main/java/WebProject/withpet/pets/domain/Comsumption.java
@@ -1,4 +1,4 @@
-package WebProject.withpet.consumptions.domain;
+package WebProject.withpet.pets.domain;
 
 import WebProject.withpet.common.domain.BaseEntity;
 import WebProject.withpet.pets.domain.Pet;

--- a/src/main/java/WebProject/withpet/pets/domain/Consumption.java
+++ b/src/main/java/WebProject/withpet/pets/domain/Consumption.java
@@ -10,6 +10,8 @@ import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -17,6 +19,8 @@ import lombok.NoArgsConstructor;
 @Table(name = "consumptions")
 @Getter
 @NoArgsConstructor
+@Builder
+@AllArgsConstructor
 public class Consumption extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -39,4 +43,21 @@ public class Consumption extends BaseEntity {
     private Long beauty;
 
     private Long etc;
+
+    private int year;
+    private int month;
+    private int week;
+    private int day;
+
+    public void update(Consumption updateConsumption) {
+        feed = updateConsumption.feed;
+        toy = updateConsumption.toy;
+        hospital = updateConsumption.hospital;
+        beauty = updateConsumption.beauty;
+        etc = updateConsumption.etc;
+        year = updateConsumption.year;
+        month = updateConsumption.month;
+        week = updateConsumption.week;
+        day = updateConsumption.day;
+    }
 }

--- a/src/main/java/WebProject/withpet/pets/domain/Consumption.java
+++ b/src/main/java/WebProject/withpet/pets/domain/Consumption.java
@@ -1,7 +1,6 @@
 package WebProject.withpet.pets.domain;
 
 import WebProject.withpet.common.domain.BaseEntity;
-import WebProject.withpet.pets.domain.Pet;
 import WebProject.withpet.users.domain.User;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
@@ -18,7 +17,7 @@ import lombok.NoArgsConstructor;
 @Table(name = "consumptions")
 @Getter
 @NoArgsConstructor
-public class Comsumption extends BaseEntity {
+public class Consumption extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;

--- a/src/main/java/WebProject/withpet/pets/domain/ConsumptionRepository.java
+++ b/src/main/java/WebProject/withpet/pets/domain/ConsumptionRepository.java
@@ -1,0 +1,8 @@
+package WebProject.withpet.pets.domain;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ConsumptionRepository extends JpaRepository<Consumption, Long>, ConsumptionRepositoryCustom {
+}

--- a/src/main/java/WebProject/withpet/pets/domain/ConsumptionRepositoryCustom.java
+++ b/src/main/java/WebProject/withpet/pets/domain/ConsumptionRepositoryCustom.java
@@ -1,10 +1,14 @@
 package WebProject.withpet.pets.domain;
 
 import WebProject.withpet.pets.dto.ConsumptionResponseDto;
+import WebProject.withpet.pets.dto.MonthlyConsumptionByUserResponseDto;
+import WebProject.withpet.users.domain.User;
 import java.util.List;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface ConsumptionRepositoryCustom {
-    List<ConsumptionResponseDto> findMonthlyConsumptions(Pet pet, int year, int month);
+    List<ConsumptionResponseDto> findMonthlyConsumptionsByPet(Pet pet, int year, int month);
+
+    List<MonthlyConsumptionByUserResponseDto> getDailyConsumptionsByUser(User user, int year, int month);
 }

--- a/src/main/java/WebProject/withpet/pets/domain/ConsumptionRepositoryCustom.java
+++ b/src/main/java/WebProject/withpet/pets/domain/ConsumptionRepositoryCustom.java
@@ -1,0 +1,10 @@
+package WebProject.withpet.pets.domain;
+
+import WebProject.withpet.pets.dto.ConsumptionResponseDto;
+import java.util.List;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ConsumptionRepositoryCustom {
+    List<ConsumptionResponseDto> findMonthlyConsumptions(Pet pet, int year, int month);
+}

--- a/src/main/java/WebProject/withpet/pets/domain/ConsumptionRepositoryImpl.java
+++ b/src/main/java/WebProject/withpet/pets/domain/ConsumptionRepositoryImpl.java
@@ -3,6 +3,8 @@ package WebProject.withpet.pets.domain;
 import static WebProject.withpet.pets.domain.QConsumption.consumption;
 
 import WebProject.withpet.pets.dto.ConsumptionResponseDto;
+import WebProject.withpet.pets.dto.MonthlyConsumptionByUserResponseDto;
+import WebProject.withpet.users.domain.User;
 import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
@@ -16,13 +18,24 @@ public class ConsumptionRepositoryImpl implements ConsumptionRepositoryCustom {
     private final EntityManager em;
 
     @Override
-    public List<ConsumptionResponseDto> findMonthlyConsumptions(Pet pet, int year, int month) {
+    public List<ConsumptionResponseDto> findMonthlyConsumptionsByPet(Pet pet, int year, int month) {
         JPAQueryFactory queryFactory = new JPAQueryFactory(em);
 
         return queryFactory.select(
                         Projections.fields(ConsumptionResponseDto.class, consumption.id, consumption.toy, consumption.hospital,
-                                consumption.beauty, consumption.etc, consumption.year, consumption.month, consumption.week,
-                                consumption.day)).from(consumption)
+                                consumption.beauty, consumption.etc, consumption.day)).from(consumption)
                 .where(consumption.pet.eq(pet), consumption.year.eq(year), consumption.month.eq(month)).fetch();
     }
+
+    @Override
+    public List<MonthlyConsumptionByUserResponseDto> getDailyConsumptionsByUser(User user, int year, int month) {
+        JPAQueryFactory queryFactory = new JPAQueryFactory(em);
+
+        return queryFactory.select(Projections.fields(MonthlyConsumptionByUserResponseDto.class, consumption.day,
+                        consumption.toy.sum().as("toySum"), consumption.hospital.sum().as("hospitalSum"),
+                        consumption.beauty.sum().as("beautySum"), consumption.etc.sum().as("etcSum"))).from(consumption)
+                .where(consumption.pet.user.eq(user), consumption.year.eq(year), consumption.month.eq(month))
+                .groupBy(consumption.day).fetch();
+    }
+
 }

--- a/src/main/java/WebProject/withpet/pets/domain/ConsumptionRepositoryImpl.java
+++ b/src/main/java/WebProject/withpet/pets/domain/ConsumptionRepositoryImpl.java
@@ -1,0 +1,28 @@
+package WebProject.withpet.pets.domain;
+
+import static WebProject.withpet.pets.domain.QConsumption.consumption;
+
+import WebProject.withpet.pets.dto.ConsumptionResponseDto;
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import javax.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class ConsumptionRepositoryImpl implements ConsumptionRepositoryCustom {
+    private final EntityManager em;
+
+    @Override
+    public List<ConsumptionResponseDto> findMonthlyConsumptions(Pet pet, int year, int month) {
+        JPAQueryFactory queryFactory = new JPAQueryFactory(em);
+
+        return queryFactory.select(
+                        Projections.fields(ConsumptionResponseDto.class, consumption.id, consumption.toy, consumption.hospital,
+                                consumption.beauty, consumption.etc, consumption.year, consumption.month, consumption.week,
+                                consumption.day)).from(consumption)
+                .where(consumption.pet.eq(pet), consumption.year.eq(year), consumption.month.eq(month)).fetch();
+    }
+}

--- a/src/main/java/WebProject/withpet/pets/domain/Pet.java
+++ b/src/main/java/WebProject/withpet/pets/domain/Pet.java
@@ -5,7 +5,6 @@ import WebProject.withpet.users.domain.User;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
-import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
@@ -44,8 +43,14 @@ public class Pet {
     @DateTimeFormat(pattern = "yyyy-MM-DD")
     private LocalDate birthday;
 
-    @OneToMany(mappedBy = "pet", cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "pet", orphanRemoval = true)
     private List<Challenge> challenges = new ArrayList<>();
+
+    @OneToMany(mappedBy = "pet", orphanRemoval = true)
+    private List<HealthCare> healthCares = new ArrayList<>();
+
+    @OneToMany(mappedBy = "pet", orphanRemoval = true)
+    private List<Consumption> consumptions = new ArrayList<>();
 
     @Builder
     public Pet(

--- a/src/main/java/WebProject/withpet/pets/dto/ConsumptionRequestDto.java
+++ b/src/main/java/WebProject/withpet/pets/dto/ConsumptionRequestDto.java
@@ -1,0 +1,41 @@
+package WebProject.withpet.pets.dto;
+
+import WebProject.withpet.pets.domain.Consumption;
+import WebProject.withpet.pets.domain.Pet;
+import WebProject.withpet.users.domain.User;
+import javax.validation.constraints.Max;
+import javax.validation.constraints.Min;
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class ConsumptionRequestDto {
+    private final Long feed;
+
+    private Long toy;
+
+    private Long hospital;
+
+    private Long beauty;
+
+    private Long etc;
+
+    @Min(2023)
+    private int year;
+    @Min(1)
+    @Max(12)
+    private int month;
+    @Min(1)
+    @Max(5)
+    private int week;
+
+    @Min(1)
+    @Max(31)
+    private int day;
+
+    public Consumption toEntity(User user, Pet pet) {
+        return Consumption.builder().pet(pet).user(user).feed(feed).toy(toy).hospital(hospital).beauty(beauty).etc(etc)
+                .year(year).month(month).week(week).day(day).build();
+    }
+}

--- a/src/main/java/WebProject/withpet/pets/dto/ConsumptionResponseDto.java
+++ b/src/main/java/WebProject/withpet/pets/dto/ConsumptionResponseDto.java
@@ -1,6 +1,5 @@
 package WebProject.withpet.pets.dto;
 
-import javax.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -18,8 +17,5 @@ public class ConsumptionResponseDto {
     private Long beauty;
     private Long etc;
 
-    private int year;
-    private int month;
-    private int week;
     private int day;
 }

--- a/src/main/java/WebProject/withpet/pets/dto/ConsumptionResponseDto.java
+++ b/src/main/java/WebProject/withpet/pets/dto/ConsumptionResponseDto.java
@@ -1,0 +1,25 @@
+package WebProject.withpet.pets.dto;
+
+import javax.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Builder
+@AllArgsConstructor
+@Getter
+@NoArgsConstructor
+public class ConsumptionResponseDto {
+    private Long id;
+
+    private Long toy;
+    private Long hospital;
+    private Long beauty;
+    private Long etc;
+
+    private int year;
+    private int month;
+    private int week;
+    private int day;
+}

--- a/src/main/java/WebProject/withpet/pets/dto/MonthlyConsumptionByPetResponseDto.java
+++ b/src/main/java/WebProject/withpet/pets/dto/MonthlyConsumptionByPetResponseDto.java
@@ -1,0 +1,18 @@
+package WebProject.withpet.pets.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class MonthlyConsumptionByPetResponseDto {
+    private int day;
+    private ConsumptionResponseDto consumption;
+
+    public MonthlyConsumptionByPetResponseDto(
+            ConsumptionResponseDto consumption
+    ) {
+        day = consumption.getDay();
+        this.consumption = consumption;
+    }
+}

--- a/src/main/java/WebProject/withpet/pets/dto/MonthlyConsumptionByUserResponseDto.java
+++ b/src/main/java/WebProject/withpet/pets/dto/MonthlyConsumptionByUserResponseDto.java
@@ -1,0 +1,13 @@
+package WebProject.withpet.pets.dto;
+
+import lombok.Getter;
+
+@Getter
+public class MonthlyConsumptionByUserResponseDto {
+    private int day;
+
+    private Long toySum;
+    private Long hospitalSum;
+    private Long beautySum;
+    private Long etcSum;
+}

--- a/src/main/java/WebProject/withpet/pets/service/ConsumptionService.java
+++ b/src/main/java/WebProject/withpet/pets/service/ConsumptionService.java
@@ -1,0 +1,54 @@
+package WebProject.withpet.pets.service;
+
+import WebProject.withpet.common.exception.DataNotFoundException;
+import WebProject.withpet.pets.domain.Consumption;
+import WebProject.withpet.pets.domain.ConsumptionRepository;
+import WebProject.withpet.pets.domain.Pet;
+import WebProject.withpet.pets.dto.ConsumptionRequestDto;
+import WebProject.withpet.pets.dto.ConsumptionResponseDto;
+import WebProject.withpet.users.domain.User;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ConsumptionService {
+    private final ConsumptionRepository consumptionRepository;
+    private final PetService petService;
+
+    @Transactional
+    public void saveConsumption(Long petId, User user, ConsumptionRequestDto request) {
+        Pet pet = petService.accessPet(user, petId);
+        consumptionRepository.save(request.toEntity(user, pet));
+    }
+
+    @Transactional
+    public void updateConsumption(Long consumptionId, Long petId, User user, ConsumptionRequestDto request) {
+        Pet pet = petService.accessPet(user, petId);
+        Consumption consumption = findConsumptionById(consumptionId);
+        consumption.update(request.toEntity(user, pet));
+    }
+
+    @Transactional
+    public void deleteConsumption(Long consumptionId, Long petId, User user) {
+        Consumption consumption = accessConsumption(petId, consumptionId, user);
+        consumptionRepository.delete(consumption);
+    }
+
+    @Transactional(readOnly = true)
+    public List<ConsumptionResponseDto> getMonthlyConsumptions(Long petId, User user, int year, int month) {
+        Pet pet = petService.accessPet(user, petId);
+        return consumptionRepository.findMonthlyConsumptions(pet, year, month);
+    }
+
+    private Consumption findConsumptionById(Long id) {
+        return consumptionRepository.findById(id).orElseThrow(DataNotFoundException::new);
+    }
+
+    public Consumption accessConsumption(Long petId, Long consumptionId, User user) {
+        petService.accessPet(user, petId);
+        return findConsumptionById(consumptionId);
+    }
+}

--- a/src/main/java/WebProject/withpet/pets/service/ConsumptionService.java
+++ b/src/main/java/WebProject/withpet/pets/service/ConsumptionService.java
@@ -4,9 +4,13 @@ import WebProject.withpet.common.exception.DataNotFoundException;
 import WebProject.withpet.pets.domain.Consumption;
 import WebProject.withpet.pets.domain.ConsumptionRepository;
 import WebProject.withpet.pets.domain.Pet;
+import WebProject.withpet.pets.domain.PetRepository;
 import WebProject.withpet.pets.dto.ConsumptionRequestDto;
 import WebProject.withpet.pets.dto.ConsumptionResponseDto;
+import WebProject.withpet.pets.dto.MonthlyConsumptionByPetResponseDto;
+import WebProject.withpet.pets.dto.MonthlyConsumptionByUserResponseDto;
 import WebProject.withpet.users.domain.User;
+import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -17,6 +21,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class ConsumptionService {
     private final ConsumptionRepository consumptionRepository;
     private final PetService petService;
+    private final PetRepository petRepository;
 
     @Transactional
     public void saveConsumption(Long petId, User user, ConsumptionRequestDto request) {
@@ -38,9 +43,20 @@ public class ConsumptionService {
     }
 
     @Transactional(readOnly = true)
-    public List<ConsumptionResponseDto> getMonthlyConsumptions(Long petId, User user, int year, int month) {
+    public List<MonthlyConsumptionByPetResponseDto> getMonthlyConsumptionsByPet(Long petId, User user, int year,
+                                                                                int month) {
         Pet pet = petService.accessPet(user, petId);
-        return consumptionRepository.findMonthlyConsumptions(pet, year, month);
+        List<ConsumptionResponseDto> consumptions = consumptionRepository.findMonthlyConsumptionsByPet(pet, year,
+                month);
+
+        List<MonthlyConsumptionByPetResponseDto> response = new ArrayList<>();
+        consumptions.forEach(consumption -> response.add(new MonthlyConsumptionByPetResponseDto(consumption)));
+        return response;
+    }
+
+    @Transactional(readOnly = true)
+    public List<MonthlyConsumptionByUserResponseDto> getMonthlyConsumptionsByUser(User user, int year, int month) {
+        return consumptionRepository.getDailyConsumptionsByUser(user, year, month);
     }
 
     private Consumption findConsumptionById(Long id) {


### PR DESCRIPTION
## 📌 관련 이슈
closed #43 

## ✨ 추가된 내용
1. 가계부 기능 구현


## 📚 논의사항
- 우선은 구현해두고, 추후에 유효성 검사 관련 로직을 추가할 생각입니다.
- 현재 챌린지, 가계부, 건강관리 기능 모두에 year, month, week, day 라는 컬럼이 들어갑니다. 이를 하나의 테이블로 빼는게 좋을까요?
- 빼는 것이 좋다고 고민한 이유 : 컬럼 중복
- 빼지 않아도 된다고 생각한 이유 : 쿼리를 날릴 때 챌린지, 가계부 건강관리를 한꺼번에 건드는 로직이 있다면 조인하는 것이 합당하겠지만 현재까지는 그런 기능이 없어서 필요없지 않을까 고민됨
