### PR TITLE
refactor: HealthCareRepository 수정에 따른 쓰이지 않는 의존성 삭제

### DIFF
--- a/src/main/java/WebProject/withpet/pets/domain/HealthCareRepository.java
+++ b/src/main/java/WebProject/withpet/pets/domain/HealthCareRepository.java
@@ -4,5 +4,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface HealthCareRepository extends JpaRepository<HealthCare, Long> {
+public interface HealthCareRepository extends JpaRepository<HealthCare, Long>, HealthCareRepositoryCustom {
 }

--- a/src/main/java/WebProject/withpet/pets/domain/HealthCareRepositoryImpl.java
+++ b/src/main/java/WebProject/withpet/pets/domain/HealthCareRepositoryImpl.java
@@ -20,11 +20,10 @@ public class HealthCareRepositoryImpl implements HealthCareRepositoryCustom {
     public List<HealthCareResponseDto> findMonthlyHealthCares(Pet pet, int year, int month) {
         JPAQueryFactory queryFactory = new JPAQueryFactory(em);
 
-        return queryFactory.select(Projections.fields(HealthCareResponseDto.class, healthCare.id,
-                        healthCare.walkDistance, healthCare.weight, healthCare.drinkAmount, healthCare.feedAmount,
-                        healthCare.diary, healthCare.year, healthCare.month, healthCare.week, healthCare.day))
-                .from(healthCare)
-                .where(healthCare.pet.eq(pet), healthCare.year.eq(year), healthCare.month.eq(month))
-                .fetch();
+        return queryFactory.select(
+                        Projections.fields(HealthCareResponseDto.class, healthCare.id, healthCare.walkDistance,
+                                healthCare.weight, healthCare.drinkAmount, healthCare.feedAmount, healthCare.diary,
+                                healthCare.year, healthCare.month, healthCare.week, healthCare.day)).from(healthCare)
+                .where(healthCare.pet.eq(pet), healthCare.year.eq(year), healthCare.month.eq(month)).fetch();
     }
 }

--- a/src/main/java/WebProject/withpet/pets/service/HealthCareService.java
+++ b/src/main/java/WebProject/withpet/pets/service/HealthCareService.java
@@ -3,7 +3,6 @@ package WebProject.withpet.pets.service;
 import WebProject.withpet.common.exception.DataNotFoundException;
 import WebProject.withpet.pets.domain.HealthCare;
 import WebProject.withpet.pets.domain.HealthCareRepository;
-import WebProject.withpet.pets.domain.HealthCareRepositoryCustom;
 import WebProject.withpet.pets.domain.Pet;
 import WebProject.withpet.pets.dto.HealthCareRequestDto;
 import WebProject.withpet.pets.dto.HealthCareResponseDto;
@@ -17,7 +16,6 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class HealthCareService {
     private final HealthCareRepository healthCareRepository;
-    private final HealthCareRepositoryCustom healthCareRepositoryCustom;
     private final PetService petService;
 
     @Transactional
@@ -41,7 +39,7 @@ public class HealthCareService {
     @Transactional(readOnly = true)
     public List<HealthCareResponseDto> getMonthlyHealthCares(Long petId, User user, int year, int month) {
         Pet pet = petService.accessPet(user, petId);
-        return healthCareRepositoryCustom.findMonthlyHealthCares(pet, year, month);
+        return healthCareRepository.findMonthlyHealthCares(pet, year, month);
     }
 
     private HealthCare findHealthCareById(Long id) {


### PR DESCRIPTION
## ✨ 추가된 내용
기존에 HealthCareRepositoryCustom 을 직접 주입해서 사용했는데, HealthCareRepository 가 이를 상속하도록 수정하고 그에 따라 의존성 주입을 삭제했습니다.

