### PR TITLE
API 테스트 중에 발생한 401에러 수정, 게시글 검색 api와 필터링 api를 하나로 통일에 따른 코드 수정, 게시글 삭제 구현

### DIFF
--- a/src/main/java/WebProject/withpet/articles/domain/Article.java
+++ b/src/main/java/WebProject/withpet/articles/domain/Article.java
@@ -51,18 +51,17 @@ public class Article extends BaseEntity {
 
     private Integer likeCnt;
 
-
     private String title;
 
     private String detailText;
 
-    @OneToMany(mappedBy = "article")
+    @OneToMany(mappedBy = "article", cascade = CascadeType.REMOVE)
     private List<Image> images = new ArrayList<>();
 
-    @OneToMany(mappedBy = "article", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToMany(mappedBy = "article", cascade = CascadeType.REMOVE)
     private List<Comment> comments = new ArrayList<>();
 
-    @OneToMany(mappedBy = "article", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToMany(mappedBy = "article", cascade = CascadeType.REMOVE)
     private List<ArticleLike> articleLikes = new ArrayList<>();
 
     @Builder
@@ -85,16 +84,24 @@ public class Article extends BaseEntity {
         }
     }
 
-    public void update(String title,String detailText) {
+    public void update(String title, String detailText) {
 
         if (title != null) {
             this.title = title;
         }
 
-        if (title != null) {
+        if (detailText != null) {
             this.detailText = detailText;
         }
 
+    }
+
+    public void plusLikeCnt(){
+        this.likeCnt+=1;
+    }
+
+    public void minusLikeCnt(){
+        this.likeCnt-=1;
     }
 
 }

--- a/src/main/java/WebProject/withpet/articles/domain/SpecArticle.java
+++ b/src/main/java/WebProject/withpet/articles/domain/SpecArticle.java
@@ -35,7 +35,16 @@ public class SpecArticle extends Article {
         this.place2 = place2;
     }
 
-    public void update(SpecArticle specArticle) {
+    public void update(String title, String detailText,String place1, String place2) {
+
+        super.update(title,detailText);
+
+        if (place1 != null) {
+            this.place1 = place1;
+        }
+        if (place2 != null) {
+            this.place2 = place2;
+        }
 
     }
 }

--- a/src/main/java/WebProject/withpet/articles/dto/ViewArticleListDto.java
+++ b/src/main/java/WebProject/withpet/articles/dto/ViewArticleListDto.java
@@ -17,6 +17,8 @@ public class ViewArticleListDto {
 
     private String nickName;
 
+    private String title;
+
     private LocalDateTime createdTime;
 
     private LocalDateTime modifiedTime;
@@ -29,20 +31,27 @@ public class ViewArticleListDto {
 
     private Tag tag;
 
-    private Long articleLikeId;
+    private Long articleLikeUserId;
 
-    public ViewArticleListDto(Long articleId, String profileImg, String nickName,
+    private Boolean whetherLike;
+
+    public ViewArticleListDto(Long articleId, String profileImg, String nickName, String title,
         LocalDateTime createdTime, LocalDateTime modifiedTime, String detailText, Integer likeCnt,
-        Integer commentCnt, Tag tag, Long articleLikeId) {
+        Integer commentCnt, Tag tag, Long articleLikeUserId) {
         this.articleId = articleId;
         this.profileImg = profileImg;
         this.nickName = nickName;
+        this.title = title;
         this.createdTime = createdTime;
         this.modifiedTime = modifiedTime;
         this.detailText = detailText;
         this.likeCnt = likeCnt;
         this.commentCnt = commentCnt;
         this.tag = tag;
-        this.articleLikeId = articleLikeId;
+        this.articleLikeUserId = articleLikeUserId;
+    }
+
+    public void setWhetherLike(Boolean b){
+        whetherLike=b;
     }
 }

--- a/src/main/java/WebProject/withpet/articles/dto/ViewArticleListRequestDto.java
+++ b/src/main/java/WebProject/withpet/articles/dto/ViewArticleListRequestDto.java
@@ -25,4 +25,6 @@ public class ViewArticleListRequestDto {
 
     private Integer size;
 
+    private String param;
+
 }

--- a/src/main/java/WebProject/withpet/articles/dto/ViewArticleListResponseDto.java
+++ b/src/main/java/WebProject/withpet/articles/dto/ViewArticleListResponseDto.java
@@ -15,6 +15,8 @@ public class ViewArticleListResponseDto {
 
     private Boolean hasNext;
 
+    private Long lastArticleId;
+
     @Builder.Default
     private List<ViewArticleListDto> viewArticleListDtoList = new ArrayList<>();
 }

--- a/src/main/java/WebProject/withpet/articles/repository/ArticleRepository.java
+++ b/src/main/java/WebProject/withpet/articles/repository/ArticleRepository.java
@@ -3,6 +3,7 @@ package WebProject.withpet.articles.repository;
 import WebProject.withpet.articles.domain.Article;
 import WebProject.withpet.articles.domain.SpecArticle;
 import WebProject.withpet.articles.dto.MypageArticleDto;
+import WebProject.withpet.users.domain.User;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -14,4 +15,5 @@ import org.springframework.stereotype.Repository;
 public interface ArticleRepository<T extends Article> extends JpaRepository<T, Long>,
     ArticleRepositoryCustom, ArticleRepositoryPagingCustom {
 
+    Optional<Article> findByUser(User user);
 }

--- a/src/main/java/WebProject/withpet/articles/repository/ArticleRepositoryPagingCustomImpl.java
+++ b/src/main/java/WebProject/withpet/articles/repository/ArticleRepositoryPagingCustomImpl.java
@@ -61,16 +61,16 @@ public class ArticleRepositoryPagingCustomImpl implements ArticleRepositoryPagin
 
         List<ViewArticleListDto> response = queryFactory
             .select(Projections.constructor(ViewArticleListDto.class,
-                article.id, user.profileImg,
-                user.nickName, article.createdTime, article.modifiedTime, article.detailText,
-                article.likeCnt, article.comments.size(), article.tag, articleLike.id
+                article.id, user.profileImg, user.nickName, article.title, article.createdTime,
+                article.modifiedTime, article.detailText, article.likeCnt, article.comments.size(),
+                article.tag, articleLike.user.id
             ))
             .from(article)
             .leftJoin(article.user, user)
             .leftJoin(article.articleLikes, articleLike)
             .leftJoin(specArticle).on(article.id.eq(specArticle.id))
             .where(tagEq(dto.getTag(), dto.getPlace1(), dto.getPlace2()),
-                lastIdGtOrLt(lastArticle, dto))
+                lastIdGtOrLt(lastArticle, dto), paramContain(dto.getParam()))
             .orderBy(filterEq(dto.getFilter()))
             .limit(pageable.getPageSize() + 1)
             .fetch();
@@ -78,6 +78,7 @@ public class ArticleRepositoryPagingCustomImpl implements ArticleRepositoryPagin
         return checkLastPage(response, pageable);
 
     }
+
 
     private Slice<ViewArticleListDto> checkLastPage(List<ViewArticleListDto> articleList,
         Pageable pageable) {
@@ -94,12 +95,12 @@ public class ArticleRepositoryPagingCustomImpl implements ArticleRepositoryPagin
 
     //동적 쿼리를 위해 사용되었습니다.(tag,place1,place2 동적 조건에 따른 필터링)
     private BooleanExpression tagEq(Tag tag, String place1, String place2) {
-            //전체 조회
-        if (tag == null && place1==null) {
+        //전체 조회
+        if (tag == null && place1 == null) {
             return null;
 
             //지역1로 전체 조회(ex.태크 상관 없이 서울시 전체)
-        } else if (tag ==null && place1 != null) {
+        } else if (tag == null && place1 != null) {
             return specArticle.place1.eq(place1);
 
             //특정 태그(lost,walk,hospital)와 장소 1,2 모두 조건에 있는 경우
@@ -133,6 +134,15 @@ public class ArticleRepositoryPagingCustomImpl implements ArticleRepositoryPagin
             return article.modifiedTime.before(lastArticle.getModifiedTime());
         }
 
+    }
+
+    //검색어 필터링을 위해 사용되었습니다.
+    private BooleanExpression paramContain(String param) {
+        if (param == null) {
+            return null;
+        } else {
+            return article.title.contains(param);
+        }
     }
 
     //동적 쿼리를 위해 사용되었습니다.(filter의 동적 조건에 따른 오름.내림차순 필터링)

--- a/src/main/java/WebProject/withpet/articles/service/ArticleLikeService.java
+++ b/src/main/java/WebProject/withpet/articles/service/ArticleLikeService.java
@@ -38,6 +38,7 @@ public class ArticleLikeService {
 
         ArticleLike createArticleLike = dto.toEntity(findUser, findArticle);
         findArticle.getArticleLikes().add(createArticleLike);
+        findArticle.plusLikeCnt();
         articleLikeRepository.save(createArticleLike);
 
     }
@@ -53,6 +54,8 @@ public class ArticleLikeService {
             .orElseThrow(() -> new UnauthorizedException(ErrorCode.ARTICLE_LIKE_UNAUTHORIZED));
 
         findArticle.getArticleLikes().remove(findArticleLike);
+        findArticle.minusLikeCnt();
+        articleLikeRepository.delete(findArticleLike);
 
     }
 

--- a/src/main/java/WebProject/withpet/articles/service/ImageService.java
+++ b/src/main/java/WebProject/withpet/articles/service/ImageService.java
@@ -34,6 +34,16 @@ public class ImageService {
         return response;
     }
 
+    @Transactional
+    public void deleteImage(ImageDto dto){
+
+        Image findImage = imageRepository.findByContent(dto.getContent())
+            .orElseThrow(() -> new DataNotFoundException());
+
+        findImage.getArticle().getImages().remove(findImage);
+        awsS3Service.deleteImage(dto.getContent());
+        imageRepository.delete(findImage);
+    }
 
 
 }

--- a/src/main/java/WebProject/withpet/comments/controller/CommentController.java
+++ b/src/main/java/WebProject/withpet/comments/controller/CommentController.java
@@ -64,7 +64,7 @@ public class CommentController {
         return ResponseEntity.status(HttpStatus.OK).body(response);
     }
 
-    @PatchMapping("/comments/{commentId}")
+    @PatchMapping("/comment/{commentId}")
     public ResponseEntity<ApiResponse<Void>> updateComment(
         @AuthenticationPrincipal PrincipalDetails principalDetails,
         @PathVariable("commentId") @NotNull(message = "변경할 댓글 id는 필수 값입니다.") Long commentId,
@@ -75,7 +75,7 @@ public class CommentController {
         return ResponseEntity.status(HttpStatus.OK).body(ResponseConstants.RESPONSE_UPDATE_OK);
     }
 
-    @DeleteMapping("/comments/{commentId}")
+    @DeleteMapping("/comment/{commentId}")
     public ResponseEntity<ApiResponse<Void>> deleteComment(
         @AuthenticationPrincipal PrincipalDetails principalDetails,
         @PathVariable("commentId") Long commentId) {

--- a/src/main/java/WebProject/withpet/comments/service/CommentService.java
+++ b/src/main/java/WebProject/withpet/comments/service/CommentService.java
@@ -111,17 +111,24 @@ public class CommentService {
         checkUserAuthorization(user, commentId);
 
         Comment findComment = findCommentById(commentId);
-        findComment.deleteConnectionWithUser(userService.findUserById(user.getId()));
+        User findUser = userService.findUserById(user.getId());
+        findComment.deleteConnectionWithUser(findUser);
 
+        List<Comment> commentsArticleHas = findComment.getArticle().getComments();
 
         if(!findComment.getChildren().isEmpty()){
 
             List<Comment> childrenComment = commentRepository.findAllByParent(findComment);
-            childrenComment.forEach(c->commentRepository.delete(c));
+
+            childrenComment.forEach(comment->{
+                commentsArticleHas.remove(comment);
+                comment.deleteConnectionWithUser(findUser);
+                commentRepository.deleteById(comment.getId());
+            });
         }
 
+        commentsArticleHas.remove(findComment);
         commentRepository.delete(findComment);
-
 
     }
 

--- a/src/main/java/WebProject/withpet/common/config/SecurityConfig.java
+++ b/src/main/java/WebProject/withpet/common/config/SecurityConfig.java
@@ -51,7 +51,7 @@ public class SecurityConfig {
             .addFilter(new JwtAuthorizationFilter(authentication, jwtTokenProvider))
             .authorizeRequests();
 
-        http.authorizeRequests().antMatchers("/user/**", "/mypage/**").permitAll()
+        http.authorizeRequests().antMatchers("/user/**", "/articles/**","/comments").permitAll()
             .and()
             .headers()
             .addHeaderWriter(new XFrameOptionsHeaderWriter(

--- a/src/main/java/WebProject/withpet/common/config/WebConfig.java
+++ b/src/main/java/WebProject/withpet/common/config/WebConfig.java
@@ -18,7 +18,7 @@ public class WebConfig implements WebMvcConfigurer {
         registry.addInterceptor(new JwtAuthInterceptor(jwtTokenProvider))
 
             .addPathPatterns("/pet/**", "/mypage/**", "/{petId}/challenge/**", "/article/**",
-                "/image/**", "/comment/**","article_like/**","/user/duplicate","/user/password");
+                "/image/**", "/comment/**","/article_like/**","/user/duplicate","/user/password");
 
 
     }

--- a/src/main/java/WebProject/withpet/common/config/WebConfig.java
+++ b/src/main/java/WebProject/withpet/common/config/WebConfig.java
@@ -17,10 +17,9 @@ public class WebConfig implements WebMvcConfigurer {
     public void addInterceptors(InterceptorRegistry registry) {
         registry.addInterceptor(new JwtAuthInterceptor(jwtTokenProvider))
 
-
-
             .addPathPatterns("/pet/**", "/mypage/**", "/{petId}/challenge/**", "/article/**",
-                "/image/**", "/comment/**", "/comments/**","article_like/**");
+                "/image/**", "/comment/**","article_like/**","/user/duplicate","/user/password");
+
 
     }
 


### PR DESCRIPTION
## 📌 관련 이슈



## ✨ 추가된 내용
1. cascade = CascadeType.ALL, orphanRemoval = true는 자식 엔티티에 부모가 딱 하나만 있을때 사용하는게 좋다고하여 해당 코드를 삭제하였습니다.

2. 좋아요/ 좋아요 취소 api를 사용해도 Article likeCnt에 반영이 안 되는 오류를 해결하였습니다.
 
3. 인증이 필요 없는 API에서 401 오류가 발생하여 인터셉터를 거치는 시큐리티 URL 설정과 api url을 수정하였습니다.

4. 게시글 검색 api을 무한 스크롤 필터링 api와 합쳤습니다.따라서 param이라는 새로운 필터 조건 변수를  추가하였습니다.

5. 게시글 삭제 코드를 controller에 추가하였습니다.

6. 해당 유저가 해당 게시글을 좋아요 했는지 여부 확인이 안 되는 오류를 해결하기 위해  ArticleLike.user의 아이디와 현재 해당 api를 호출한 유저의 id값을 비교하였습니다. 이를 위해서 필터링 동적쿼리(커서기반 무한 스크롤)에서 articleLike.user.id 조회를 추가하였고 게시글 검색 api를 필터링 api와 합침으로써 검색어 필터링을 where()절에 추가하였습니다.

7. 게시글 수정,삭제 코드를 service에 추가하였습니다. checkUserAuthorization()메소드를 추가하여 해당 유저가 해당 게시글의 수정.삭제할 권한이 있는지 판단하였습니다.

8. 부모 댓글 삭제 시 자식 댓글들이 삭제 되지 않는 오류가 있었는데 해결하였습니다.


## 📚 논의사항
