### PR TITLE
feat: access token 만료 시 refresh token 을 이용하여 재발급받는 기능 구현

### DIFF
--- a/src/main/java/WebProject/withpet/auth/application/JwtTokenProvider.java
+++ b/src/main/java/WebProject/withpet/auth/application/JwtTokenProvider.java
@@ -1,6 +1,8 @@
 package WebProject.withpet.auth.application;
 
 import WebProject.withpet.auth.PrincipalDetails;
+import WebProject.withpet.auth.service.RefreshTokenService;
+import WebProject.withpet.common.exception.InvalidRefreshTokenException;
 import WebProject.withpet.common.exception.UserNotFoundException;
 import WebProject.withpet.users.domain.User;
 import WebProject.withpet.users.repository.UserRepository;
@@ -13,7 +15,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
-import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -29,9 +30,8 @@ public class JwtTokenProvider {
     @Value("${jwt.refresh-valid-time}")
     private Long refreshTokenValidTime;
     public static final String TOKEN_PREFIX = "Bearer ";
-
-    private final UserDetailsService userDetailsService;
     private final UserRepository userRepository;
+    private final RefreshTokenService refreshTokenService;
 
 
     public String createToken(User user) {
@@ -49,8 +49,8 @@ public class JwtTokenProvider {
     /*
 		 Token에 담겨있는 정보를 이용해 Authentication 객체를 반환하는 메서드
 	 */
-    public Authentication getAuthentication(String JwtToken) {
-        String token = JwtToken.replace(TOKEN_PREFIX, "");
+    public Authentication getAuthentication(String jwtToken) {
+        String token = jwtToken.replace(TOKEN_PREFIX, "");
         String email = JWT.require(Algorithm.HMAC512(secretKey)).build().verify(token).getClaim("email").asString();
 
         if (email != null) {
@@ -69,5 +69,13 @@ public class JwtTokenProvider {
 
     public String getSecretKey() {
         return secretKey;
+    }
+
+    public String getNewAccessToken(String token) throws Exception {
+        Long userId = JWT.require(Algorithm.HMAC512(secretKey)).build().verify(token).getClaim("id").asLong();
+        if (refreshTokenService.isValidToken(token, userId)) {
+            return createToken(userRepository.findById(userId).get());
+        }
+        throw new InvalidRefreshTokenException();
     }
 }

--- a/src/main/java/WebProject/withpet/auth/application/JwtTokenProvider.java
+++ b/src/main/java/WebProject/withpet/auth/application/JwtTokenProvider.java
@@ -22,7 +22,8 @@ import org.springframework.stereotype.Component;
 public class JwtTokenProvider {
     @Value("${jwt.secret-key}")
     private String secretKey;
-    public static final String HEADER_STRING = "Authorization";
+    public static final String ACCESS_TOKEN_HEADER_STRING = "Authorization";
+    public static final String REFRESH_TOKEN_HEADER_STRING = "RefreshToken";
     @Value("${jwt.valid-time}")
     private String tokenValidTime;
     @Value("${jwt.refresh-valid-time}")

--- a/src/main/java/WebProject/withpet/auth/controller/AccessTokenController.java
+++ b/src/main/java/WebProject/withpet/auth/controller/AccessTokenController.java
@@ -1,0 +1,30 @@
+package WebProject.withpet.auth.controller;
+
+import static WebProject.withpet.auth.application.JwtTokenProvider.REFRESH_TOKEN_HEADER_STRING;
+
+import WebProject.withpet.auth.application.JwtTokenProvider;
+import WebProject.withpet.common.dto.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CookieValue;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@Slf4j
+@RequestMapping("/access")
+public class AccessTokenController {
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @GetMapping
+    public ResponseEntity<ApiResponse<String>> getNewAccessToken(
+
+            @CookieValue(name = REFRESH_TOKEN_HEADER_STRING) String refreshToken) throws Exception {
+        String newAccessToken = jwtTokenProvider.getNewAccessToken(refreshToken);
+        return ResponseEntity.ok(new ApiResponse<>(200, "새로운 액세스 토큰이 발급되었습니다.", newAccessToken));
+    }
+}

--- a/src/main/java/WebProject/withpet/auth/filter/JwtAuthorizationFilter.java
+++ b/src/main/java/WebProject/withpet/auth/filter/JwtAuthorizationFilter.java
@@ -1,7 +1,7 @@
 package WebProject.withpet.auth.filter;
 
 import WebProject.withpet.auth.application.JwtTokenProvider;
-import WebProject.withpet.common.util.JwtUtil;
+import WebProject.withpet.auth.util.JwtUtil;
 import com.auth0.jwt.exceptions.TokenExpiredException;
 import java.io.IOException;
 import javax.servlet.FilterChain;
@@ -32,7 +32,7 @@ public class JwtAuthorizationFilter extends BasicAuthenticationFilter {
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain)
             throws IOException, ServletException {
-        String header = request.getHeader(JwtTokenProvider.HEADER_STRING);
+        String header = request.getHeader(JwtTokenProvider.ACCESS_TOKEN_HEADER_STRING);
         if (header == null || !header.startsWith(JwtTokenProvider.TOKEN_PREFIX)) {
             chain.doFilter(request, response);
             return;

--- a/src/main/java/WebProject/withpet/auth/service/RefreshTokenService.java
+++ b/src/main/java/WebProject/withpet/auth/service/RefreshTokenService.java
@@ -2,6 +2,7 @@ package WebProject.withpet.auth.service;
 
 import WebProject.withpet.auth.domain.RefreshToken;
 import WebProject.withpet.auth.domain.RefreshTokenRepository;
+import WebProject.withpet.common.exception.DataNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -13,9 +14,17 @@ public class RefreshTokenService {
 
     @Transactional
     public void createOrChangeRefreshToken(String refreshToken, Long userId) {
-        refreshTokenRepository.findByUserId(userId).ifPresentOrElse(
-                (tokenEntity) -> tokenEntity.changeToken(refreshToken),
-                () -> refreshTokenRepository.save(new RefreshToken(refreshToken, userId))
-        );
+        refreshTokenRepository.findByUserId(userId)
+                .ifPresentOrElse((tokenEntity) -> tokenEntity.changeToken(refreshToken),
+                        () -> refreshTokenRepository.save(new RefreshToken(refreshToken, userId)));
+    }
+
+    public boolean isValidToken(String token, Long userId) {
+        RefreshToken refreshToken = findTokenByUserId(userId);
+        return refreshToken.getContent().equals(token);
+    }
+
+    private RefreshToken findTokenByUserId(Long userId) {
+        return refreshTokenRepository.findByUserId(userId).orElseThrow(DataNotFoundException::new);
     }
 }

--- a/src/main/java/WebProject/withpet/auth/util/JwtUtil.java
+++ b/src/main/java/WebProject/withpet/auth/util/JwtUtil.java
@@ -1,4 +1,4 @@
-package WebProject.withpet.common.util;
+package WebProject.withpet.auth.util;
 
 import WebProject.withpet.auth.application.JwtTokenProvider;
 import com.auth0.jwt.JWT;

--- a/src/main/java/WebProject/withpet/common/config/JwtAuthInterceptor.java
+++ b/src/main/java/WebProject/withpet/common/config/JwtAuthInterceptor.java
@@ -2,7 +2,7 @@ package WebProject.withpet.common.config;
 
 import WebProject.withpet.auth.application.JwtTokenProvider;
 import WebProject.withpet.common.exception.UnauthorizedException;
-import WebProject.withpet.common.util.JwtUtil;
+import WebProject.withpet.auth.util.JwtUtil;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
@@ -16,7 +16,7 @@ public class JwtAuthInterceptor implements HandlerInterceptor {
     @Override
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler)
             throws Exception {
-        String header = request.getHeader(JwtTokenProvider.HEADER_STRING);
+        String header = request.getHeader(JwtTokenProvider.ACCESS_TOKEN_HEADER_STRING);
 
         if (header == null) {
             throw new UnauthorizedException();

--- a/src/main/java/WebProject/withpet/common/constants/ErrorCode.java
+++ b/src/main/java/WebProject/withpet/common/constants/ErrorCode.java
@@ -17,7 +17,10 @@ public enum ErrorCode {
     DUPLICATE_CHALLENGE(HttpStatus.CONFLICT, "반려동물의 해당 챌린지명은 이미 존재합니다."),
     DUPLICATE_ARTICLE_LIKE(HttpStatus.CONFLICT, "해당 게시물을 이미 좋아요 했습니다."),
     ARTICLE_LIKE_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "해당 게시물 좋아요를 취소하기 위해서는 게시물 좋아요가 선행되어야 합니다."),
-    EXPIRED_CONFIRMATION_TOKEN(HttpStatus.BAD_REQUEST, "해당 확인 코드는 만료되었습니다.");
+    EXPIRED_CONFIRMATION_TOKEN(HttpStatus.BAD_REQUEST, "해당 확인 코드는 만료되었습니다."),
+    EXPIRED_TOKEN(HttpStatus.BAD_REQUEST, "해당 토큰은 만료되었습니다."),
+    EXPIRED_REFRESH_TOKEN(HttpStatus.BAD_REQUEST, "해당 리프레시 토큰은 만료되었습니다.");
+
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/WebProject/withpet/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/WebProject/withpet/common/exception/GlobalExceptionHandler.java
@@ -2,6 +2,7 @@ package WebProject.withpet.common.exception;
 
 import WebProject.withpet.common.constants.ErrorCode;
 import WebProject.withpet.common.dto.ApiErrorResponse;
+import com.auth0.jwt.exceptions.TokenExpiredException;
 import javax.validation.ConstraintViolationException;
 import lombok.extern.slf4j.Slf4j;
 import org.json.JSONException;
@@ -17,7 +18,7 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(DataNotFoundException.class)
     protected ResponseEntity<ApiErrorResponse> handleDataNotFoundException(
-        DataNotFoundException e) {
+            DataNotFoundException e) {
         log.error("handleDataNotFoundException", e);
 
         return ApiErrorResponse.toResponseEntity(e.getErrorCode());
@@ -25,7 +26,7 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(UnauthorizedException.class)
     protected ResponseEntity<ApiErrorResponse> handleUnauthorizedException(
-        UnauthorizedException e) {
+            UnauthorizedException e) {
         log.error("handleUnauthorizedException", e);
 
         return ApiErrorResponse.toResponseEntity(e.getErrorCode());
@@ -33,7 +34,7 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(UserNotFoundException.class)
     protected ResponseEntity<ApiErrorResponse> handleUserNotFoundException(
-        UserNotFoundException e) {
+            UserNotFoundException e) {
         log.error("handleUserNotFoundException", e);
 
         return ApiErrorResponse.toResponseEntity(e.getErrorCode());
@@ -49,18 +50,18 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<ApiErrorResponse> handleMethodArgumentNotValidException(
-        MethodArgumentNotValidException e) {
+            MethodArgumentNotValidException e) {
         log.error("handleMethodArgumentNotValidException", e);
         return ApiErrorResponse.toResponseEntityWithErrors(ErrorCode.INVALID_PARAMETER,
-            e.getBindingResult());
+                e.getBindingResult());
     }
 
     @ExceptionHandler(ConstraintViolationException.class)
     public ResponseEntity<ApiErrorResponse> handleConstraintViolationException(
-        ConstraintViolationException e) {
+            ConstraintViolationException e) {
         log.error("handleConstraintViolationException", e);
         return ApiErrorResponse.toResponseEntityWithConstraints(ErrorCode.INVALID_PARAMETER,
-            e.getConstraintViolations());
+                e.getConstraintViolations());
     }
 
     @ExceptionHandler(DuplicateException.class)
@@ -71,22 +72,28 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(MissingServletRequestParameterException.class)
     public ResponseEntity<ApiErrorResponse> handleMissingServletRequestParameterException(
-        MissingServletRequestParameterException e) {
+            MissingServletRequestParameterException e) {
         log.error("handleMissingServletRequestParameterException", e);
         return ApiErrorResponse.toResponseEntityWithRequestParameterException(
-            ErrorCode.INVALID_PARAMETER, e);
+                ErrorCode.INVALID_PARAMETER, e);
     }
 
     @ExceptionHandler(ArticleException.class)
     public ResponseEntity<ApiErrorResponse> handleArticleCreateException(ArticleException e) {
         log.error("handleArticleCreateException", e);
         return ApiErrorResponse.toResponseEntityWithErrors(e.getErrorCode(),
-            e.getErrors());
+                e.getErrors());
     }
 
     @ExceptionHandler(CustomException.class)
     public ResponseEntity<ApiErrorResponse> handleCustomException(CustomException e) {
         log.error("handleCustomException", e);
+        return ApiErrorResponse.toResponseEntity(e.getErrorCode());
+    }
+
+    @ExceptionHandler(InvalidRefreshTokenException.class)
+    public ResponseEntity<ApiErrorResponse> handleInvalidRefreshTokenException(InvalidRefreshTokenException e) {
+        log.error("handleInvalidRefreshTokenException", e);
         return ApiErrorResponse.toResponseEntity(e.getErrorCode());
     }
 }

--- a/src/main/java/WebProject/withpet/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/WebProject/withpet/common/exception/GlobalExceptionHandler.java
@@ -96,4 +96,10 @@ public class GlobalExceptionHandler {
         log.error("handleInvalidRefreshTokenException", e);
         return ApiErrorResponse.toResponseEntity(e.getErrorCode());
     }
+
+    @ExceptionHandler(TokenExpiredException.class)
+    public ResponseEntity<ApiErrorResponse> handleTokenExpiredException(TokenExpiredException e) {
+        log.error("handleTokenExpiredException", e);
+        return ApiErrorResponse.toResponseEntity(ErrorCode.EXPIRED_TOKEN);
+    }
 }

--- a/src/main/java/WebProject/withpet/common/exception/InvalidRefreshTokenException.java
+++ b/src/main/java/WebProject/withpet/common/exception/InvalidRefreshTokenException.java
@@ -1,0 +1,14 @@
+package WebProject.withpet.common.exception;
+
+import WebProject.withpet.common.constants.ErrorCode;
+
+public class InvalidRefreshTokenException extends CustomException {
+    public InvalidRefreshTokenException() {
+        super(ErrorCode.EXPIRED_REFRESH_TOKEN);
+    }
+
+    @Override
+    public ErrorCode getErrorCode() {
+        return super.getErrorCode();
+    }
+}

--- a/src/main/java/WebProject/withpet/users/controller/UserController.java
+++ b/src/main/java/WebProject/withpet/users/controller/UserController.java
@@ -1,7 +1,5 @@
 package WebProject.withpet.users.controller;
 
-import static WebProject.withpet.auth.application.JwtTokenProvider.TOKEN_PREFIX;
-
 import WebProject.withpet.auth.PrincipalDetails;
 import WebProject.withpet.auth.application.JwtTokenProvider;
 import WebProject.withpet.auth.dto.TokenResponseDto;
@@ -12,6 +10,7 @@ import WebProject.withpet.users.dto.ChangePasswordDto;
 import WebProject.withpet.users.dto.SocialLoginResponseDto;
 import WebProject.withpet.users.dto.UserRequestDto;
 import WebProject.withpet.users.service.UserService;
+import java.io.UnsupportedEncodingException;
 import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletResponse;
 import javax.validation.Valid;
@@ -50,37 +49,24 @@ public class UserController {
     }
 
     @PostMapping("/login")
-    public ResponseEntity<ApiResponse<String>> signIn(@Valid @RequestBody LoginVo request,
-                                                      HttpServletResponse response) {
-        TokenResponseDto tokenResponseDto = userService.login(request.getEmail(),
-                request.getPassword());
+    public ResponseEntity<ApiResponse<String>> signIn(@Valid @RequestBody LoginVo request, HttpServletResponse response)
+            throws UnsupportedEncodingException {
+        TokenResponseDto tokenResponseDto = userService.login(request.getEmail(), request.getPassword());
+        response.addCookie(createCookie(tokenResponseDto));
 
-        Cookie cookie = new Cookie("refresh-token", TOKEN_PREFIX + tokenResponseDto.getRefreshToken());
-        cookie.setMaxAge(Math.toIntExact(cookieValidTime));
-        cookie.setHttpOnly(true);
-        response.addCookie(cookie);
-
-        ApiResponse<String> apiResponse = new ApiResponse<>(200, "로그인 되었습니다.",
-                tokenResponseDto.getAccessToken());
+        ApiResponse<String> apiResponse = new ApiResponse<>(200, "로그인 되었습니다.", tokenResponseDto.getAccessToken());
         return ResponseEntity.ok(apiResponse);
     }
 
     @PostMapping("/login/kakao")
     public ResponseEntity<ApiResponse<SocialLoginResponseDto>> socialLogin(
             @RequestParam(name = "code") @NotBlank(message = "인가 코드 값은 필수입니다.") String code,
-            HttpServletResponse response)
-            throws JSONException {
+            HttpServletResponse response) throws JSONException, UnsupportedEncodingException {
 
         TokenResponseDto tokenResponseDto = userService.socialLogin(code);
+        response.addCookie(createCookie(tokenResponseDto));
 
-        Cookie cookie = new Cookie(JwtTokenProvider.REFRESH_TOKEN_HEADER_STRING,
-                TOKEN_PREFIX + tokenResponseDto.getAccessToken());
-        cookie.setMaxAge(Math.toIntExact(cookieValidTime));
-        cookie.setHttpOnly(true);
-        response.addCookie(cookie);
-
-        ApiResponse<SocialLoginResponseDto> socialLongResponse = new ApiResponse<>(200,
-                "카카오 로그인 성공",
+        ApiResponse<SocialLoginResponseDto> socialLongResponse = new ApiResponse<>(200, "카카오 로그인 성공",
                 SocialLoginResponseDto.builder().token(tokenResponseDto.getAccessToken()).build());
 
         return ResponseEntity.status(HttpStatus.OK).body(socialLongResponse);
@@ -95,9 +81,8 @@ public class UserController {
     }
 
     @PostMapping("/password")
-    public ResponseEntity<ApiResponse<Void>> changePassword(
-            @AuthenticationPrincipal PrincipalDetails principalDetails,
-            @RequestBody @Valid ChangePasswordDto changePasswordDto) {
+    public ResponseEntity<ApiResponse<Void>> changePassword(@AuthenticationPrincipal PrincipalDetails principalDetails,
+                                                            @RequestBody @Valid ChangePasswordDto changePasswordDto) {
 
         if (principalDetails != null) {
             //로그인 x한 사용자
@@ -110,11 +95,18 @@ public class UserController {
     }
 
     @DeleteMapping()
-    public ResponseEntity<ApiResponse<Void>> deleteUser(
-            @AuthenticationPrincipal PrincipalDetails principalDetails) {
+    public ResponseEntity<ApiResponse<Void>> deleteUser(@AuthenticationPrincipal PrincipalDetails principalDetails) {
 
         userService.deleteUser(principalDetails.getUser());
 
         return ResponseEntity.status(HttpStatus.OK).body(ResponseConstants.RESPONSE_DEL_OK);
+    }
+
+    private Cookie createCookie(TokenResponseDto tokenResponseDto) throws UnsupportedEncodingException {
+        Cookie cookie = new Cookie(JwtTokenProvider.REFRESH_TOKEN_HEADER_STRING, tokenResponseDto.getRefreshToken());
+        cookie.setMaxAge(Math.toIntExact(cookieValidTime));
+        cookie.setHttpOnly(true);
+        cookie.setPath("/");
+        return cookie;
     }
 }

--- a/src/main/java/WebProject/withpet/users/controller/UserController.java
+++ b/src/main/java/WebProject/withpet/users/controller/UserController.java
@@ -1,5 +1,7 @@
 package WebProject.withpet.users.controller;
 
+import static WebProject.withpet.auth.application.JwtTokenProvider.TOKEN_PREFIX;
+
 import WebProject.withpet.auth.PrincipalDetails;
 import WebProject.withpet.auth.application.JwtTokenProvider;
 import WebProject.withpet.auth.dto.TokenResponseDto;
@@ -49,37 +51,37 @@ public class UserController {
 
     @PostMapping("/login")
     public ResponseEntity<ApiResponse<String>> signIn(@Valid @RequestBody LoginVo request,
-        HttpServletResponse response) {
+                                                      HttpServletResponse response) {
         TokenResponseDto tokenResponseDto = userService.login(request.getEmail(),
-            request.getPassword());
+                request.getPassword());
 
-        Cookie cookie = new Cookie("refresh-token", tokenResponseDto.getRefreshToken());
+        Cookie cookie = new Cookie("refresh-token", TOKEN_PREFIX + tokenResponseDto.getRefreshToken());
         cookie.setMaxAge(Math.toIntExact(cookieValidTime));
         cookie.setHttpOnly(true);
         response.addCookie(cookie);
 
         ApiResponse<String> apiResponse = new ApiResponse<>(200, "로그인 되었습니다.",
-            tokenResponseDto.getAccessToken());
+                tokenResponseDto.getAccessToken());
         return ResponseEntity.ok(apiResponse);
     }
 
     @PostMapping("/login/kakao")
     public ResponseEntity<ApiResponse<SocialLoginResponseDto>> socialLogin(
-        @RequestParam(name = "code") @NotBlank(message = "인가 코드 값은 필수입니다.") String code,
-        HttpServletResponse response)
-        throws JSONException {
+            @RequestParam(name = "code") @NotBlank(message = "인가 코드 값은 필수입니다.") String code,
+            HttpServletResponse response)
+            throws JSONException {
 
         TokenResponseDto tokenResponseDto = userService.socialLogin(code);
 
-        Cookie cookie = new Cookie("refresh-token", tokenResponseDto.getAccessToken());
+        Cookie cookie = new Cookie(JwtTokenProvider.REFRESH_TOKEN_HEADER_STRING,
+                TOKEN_PREFIX + tokenResponseDto.getAccessToken());
         cookie.setMaxAge(Math.toIntExact(cookieValidTime));
         cookie.setHttpOnly(true);
         response.addCookie(cookie);
 
-
         ApiResponse<SocialLoginResponseDto> socialLongResponse = new ApiResponse<>(200,
-            "카카오 로그인 성공",
-            SocialLoginResponseDto.builder().token(tokenResponseDto.getAccessToken()).build());
+                "카카오 로그인 성공",
+                SocialLoginResponseDto.builder().token(tokenResponseDto.getAccessToken()).build());
 
         return ResponseEntity.status(HttpStatus.OK).body(socialLongResponse);
 
@@ -87,15 +89,15 @@ public class UserController {
 
     @GetMapping("/duplicate-check")
     public ResponseEntity<ApiResponse<Void>> duplicateCheck(
-        @RequestParam("nickName") @NotBlank(message = "닉네임을 입력하시오") String nickName) {
+            @RequestParam("nickName") @NotBlank(message = "닉네임을 입력하시오") String nickName) {
         userService.validateDuplicateNickname(nickName);
         return ResponseEntity.status(HttpStatus.OK).body(new ApiResponse<>(200, "사용 가능한 닉네임입니다"));
     }
 
     @PostMapping("/password")
     public ResponseEntity<ApiResponse<Void>> changePassword(
-        @AuthenticationPrincipal PrincipalDetails principalDetails,
-        @RequestBody @Valid ChangePasswordDto changePasswordDto) {
+            @AuthenticationPrincipal PrincipalDetails principalDetails,
+            @RequestBody @Valid ChangePasswordDto changePasswordDto) {
 
         if (principalDetails != null) {
             //로그인 x한 사용자
@@ -109,7 +111,7 @@ public class UserController {
 
     @DeleteMapping()
     public ResponseEntity<ApiResponse<Void>> deleteUser(
-        @AuthenticationPrincipal PrincipalDetails principalDetails) {
+            @AuthenticationPrincipal PrincipalDetails principalDetails) {
 
         userService.deleteUser(principalDetails.getUser());
 

--- a/src/main/java/WebProject/withpet/users/service/UserService.java
+++ b/src/main/java/WebProject/withpet/users/service/UserService.java
@@ -11,7 +11,6 @@ import WebProject.withpet.common.exception.DuplicateException;
 import WebProject.withpet.common.exception.UserNotFoundException;
 import WebProject.withpet.users.domain.User;
 import WebProject.withpet.users.dto.ChangePasswordDto;
-import WebProject.withpet.users.dto.SocialLoginResponseDto;
 import WebProject.withpet.users.dto.SocialUserInfoDto;
 import WebProject.withpet.users.dto.UserRequestDto;
 import WebProject.withpet.users.repository.UserRepository;
@@ -46,9 +45,8 @@ public class UserService {
         validateDuplicateEmail(userRequestDto.getEmail());
         validateDuplicateNickname(userRequestDto.getNickname());
 
-        User user = User.builder().nickName(userRequestDto.getNickname())
-            .email(userRequestDto.getEmail())
-            .password(passwordEncoder.encode(userRequestDto.getPassword())).build();
+        User user = User.builder().nickName(userRequestDto.getNickname()).email(userRequestDto.getEmail())
+                .password(passwordEncoder.encode(userRequestDto.getPassword())).build();
 
         userRepository.save(user);
     }
@@ -65,7 +63,7 @@ public class UserService {
         //회원가입
         if (userRepository.findByEmail(userInfoByToken.getEmail()).isEmpty()) {
             createUser = User.builder().email(userInfoByToken.getEmail()).password("1")
-                .nickName(userInfoByToken.getNickname()).build();
+                    .nickName(userInfoByToken.getNickname()).build();
             userRepository.save(createUser);
 
             response = getTokenInSocialLogin(createUser.getEmail(), createUser.getPassword());
@@ -116,8 +114,7 @@ public class UserService {
 
 
     public User findUserById(Long userId) {
-        return userRepository.findById(userId)
-            .orElseThrow(() -> new UserNotFoundException());
+        return userRepository.findById(userId).orElseThrow(() -> new UserNotFoundException());
     }
 
 
@@ -129,14 +126,12 @@ public class UserService {
             throw new UserNotFoundException();
         }
 
-        Authentication authentication = new UsernamePasswordAuthenticationToken(
-            principalDetails.getUsername(),
-            principalDetails.getPassword(), principalDetails.getAuthorities());
+        Authentication authentication = new UsernamePasswordAuthenticationToken(principalDetails.getUsername(),
+                principalDetails.getPassword(), principalDetails.getAuthorities());
 
         // refresh Token 생성
         String refreshToken = jwtTokenProvider.createRefreshToken(principalDetails.getUser());
-        refreshTokenService.createOrChangeRefreshToken(refreshToken,
-            principalDetails.getUser().getId());
+        refreshTokenService.createOrChangeRefreshToken(refreshToken, principalDetails.getUser().getId());
 
         String accessToken = jwtTokenProvider.createToken(principalDetails.getUser());
         SecurityContextHolder.getContext().setAuthentication(authentication);
@@ -148,14 +143,12 @@ public class UserService {
     public TokenResponseDto getTokenInSocialLogin(String email, String password) {
         PrincipalDetails principalDetails = loadUserByEmail(email);
 
-        Authentication authentication = new UsernamePasswordAuthenticationToken(
-            principalDetails.getUsername(),
-            principalDetails.getPassword(), principalDetails.getAuthorities());
+        Authentication authentication = new UsernamePasswordAuthenticationToken(principalDetails.getUsername(),
+                principalDetails.getPassword(), principalDetails.getAuthorities());
 
         // refresh Token 생성
         String refreshToken = jwtTokenProvider.createRefreshToken(principalDetails.getUser());
-        refreshTokenService.createOrChangeRefreshToken(refreshToken,
-            principalDetails.getUser().getId());
+        refreshTokenService.createOrChangeRefreshToken(refreshToken, principalDetails.getUser().getId());
 
         String accessToken = jwtTokenProvider.createToken(principalDetails.getUser());
         SecurityContextHolder.getContext().setAuthentication(authentication);
@@ -170,8 +163,7 @@ public class UserService {
     }
 
     @Transactional
-    public void permissionCheckByConfirmationToken(String requestEmail, String key,
-        LocalDateTime requestedAt) {
+    public void permissionCheckByConfirmationToken(String requestEmail, String key, LocalDateTime requestedAt) {
         confirmationTokenService.isRightKey(requestEmail, key, requestedAt);
     }
 


### PR DESCRIPTION
## 📌 관련 이슈
closed #65 


## ✨ 추가된 내용
1. 쿠키 생성 메서드 구현
2. 리프레시 토큰 유효성 검증 기능 구현
3. 액세스 토큰 만료시 리프레시 토큰을 이용하여 재발급 받는 기능 구현

## 논의사항
- prefix 를 붙여서 반환하고자 했는데, *ex) Bearer __accessToken__ 띄어쓰기가 존재해서 쿠키에서 인코딩 오류가 생깁니다. 그래서 encode 를 하려고 했더니 이도 오류가 나더라고요 그래서 우선은 prefix 가 붙지 않게 해뒀는데 이에 대해서 어떻게 생각하시는지 궁금해요 
